### PR TITLE
FDU-673 : Puesta la dependencia para que las instalaciones frescas de Op...

### DIFF
--- a/l10n_ec_niif_minimal/__openerp__.py
+++ b/l10n_ec_niif_minimal/__openerp__.py
@@ -30,6 +30,7 @@
                 'base_vat',
                 'base_iban',
                 'account_chart',
+                'ecua_partner'
                 ],
     'init_xml': [],
     'update_xml': [


### PR DESCRIPTION
...enERP 7 con l10n_ec_niif_minimal no tengan problema por no tener el campo commercial_name, y no haya que adivinar que se requiere ecua_partner.

Capaz que esto luego se corrige y AMBOS campos se mueven solamente para l10n_ec_niif_minimal para que no haya necesidad de la dependencia (es decir: que tanto la declaracion de commercial_name en la tabla res_company como la declaracion del related de commercial_name en el modulo de l10n_ec_niif_miniaml, estén dentro de este último módulo y no en módulos separados)
