### PR TITLE
FDU-812 increible. habia un codigo mal referenciado. se referenciaba a u...

### DIFF
--- a/ecua_invoice/objects/account_invoice.py
+++ b/ecua_invoice/objects/account_invoice.py
@@ -263,11 +263,11 @@ class account_invoice(osv.osv):
         if context is None:
             context = {}
         
-        if context.has_key('type'):
-            type = context ['type']
+        if 'type' in context:
+            type = context['type']
             
         if not printer_id:
-            printer_id = _default_printer_point(cr, uid, context)
+            printer_id = self._default_printer_point(cr, uid, context)
 
         number = False #por ejemplo para facturas de tipo hr_advance
         


### PR DESCRIPTION
...n metodo como si fuera una funcion global (es decir: en lugar de llamarlo como self.metodo(a, b, c) lo llamaban como metodo(a, b, c). de paso arregle otras cuestiones de codigo que quedaba mal.