### PR TITLE
2015-04-CY/FDU-759:

### DIFF
--- a/ecua_payment/data/sequence.xml
+++ b/ecua_payment/data/sequence.xml
@@ -6,7 +6,7 @@
 			<field name="name">Replenishment-Controlled</field>
  			<!-- <field name="code">replenishment.controlled</field> -->
 			<field name="padding">6</field>
-			<field name="prefix">REPOSICIÓN DE FONDO CONTROLADO/RFC </field>
+			<field name="prefix">REPOSICIÓN DE FONDOS/RFC </field>
 			<field name="number_increment">1</field>
 		    <field name="number_next">1</field>
 		    <field name="implementation">no_gap</field>

--- a/ecua_payment/i18n/es.po
+++ b/ecua_payment/i18n/es.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OpenERP Server 7.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-04-13 16:37+0000\n"
-"PO-Revision-Date: 2015-04-13 12:59-0500\n"
+"POT-Creation-Date: 2015-04-18 16:05+0000\n"
+"PO-Revision-Date: 2015-04-18 11:16-0500\n"
 "Last-Translator: Carlos Fernando\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -26,7 +26,6 @@ msgstr ""
 "<p class=\"oe_view_nocontent_create\">\n"
 "                Click para crear una nueva Reposición de Fondos Controlados.\n"
 "              </p>\n"
-"            "
 
 #. module: ecua_payment
 #: view:replenishment.controlled:0
@@ -52,8 +51,23 @@ msgstr "Importe pagado"
 
 #. module: ecua_payment
 #: view:replenishment.controlled:0
+msgid "Journal Destination"
+msgstr "Diario Destino"
+
+#. module: ecua_payment
+#: view:replenishment.controlled:0
 msgid "Confirm"
 msgstr "Confirmar"
+
+#. module: ecua_payment
+#: view:replenishment.controlled:0
+msgid "Add an internal note..."
+msgstr "Añadir una nota interna..."
+
+#. module: ecua_payment
+#: help:account.journal,maximun:0
+msgid "Maximum journal money to be controlled."
+msgstr "Valor máximo de dinero del diario a ser controlado."
 
 #. module: ecua_payment
 #: field:account.voucher,responsible_id:0
@@ -61,9 +75,9 @@ msgid "Responsible"
 msgstr "Responsable"
 
 #. module: ecua_payment
-#: field:replenishment.controlled,name:0
-msgid "Replacement fund controlled"
-msgstr "Reposición de fondo controlado"
+#: help:replenishment.controlled,journal_from_id:0
+msgid "Journal source for replenishment."
+msgstr "Diario origen para la reposición."
 
 #. module: ecua_payment
 #: view:replenishment.controlled:0
@@ -82,9 +96,9 @@ msgid "Draft"
 msgstr "Borrador"
 
 #. module: ecua_payment
-#: model:ir.model,name:ecua_payment.model_replenishment_controlled
-msgid "replenishment.controlled"
-msgstr "Reposición de Fondos Controlados"
+#: field:replenishment.controlled,narration:0
+msgid "narration"
+msgstr "Narración"
 
 #. module: ecua_payment
 #: view:replenishment.controlled:0
@@ -97,13 +111,7 @@ msgid "Confirmed Replenishment Controlled"
 msgstr "Reposición de fondos controlados confirmados"
 
 #. module: ecua_payment
-#: view:account.voucher:0
-msgid "Ejemplo: Pago de la factura #43"
-msgstr "Ejemplo: Pago de la factura #43"
-
-#. module: ecua_payment
 #: help:account.journal,controlled_funds:0
-#: help:replenishment.controlled,amount_paid:0
 msgid "Indicates that this journal will be of controlled fund."
 msgstr "Indica que este diario va a ser de fondo controlado."
 
@@ -118,9 +126,9 @@ msgid "Reference to Pay"
 msgstr "Referencia a Pago"
 
 #. module: ecua_payment
-#: view:account.journal:0
-msgid "onchange_type(type,controlled_funds)"
-msgstr "onchange_type(type,controlled_funds)"
+#: view:replenishment.controlled:0
+msgid "Replenishment Controlled"
+msgstr "Reposición de fondos controlados"
 
 #. module: ecua_payment
 #: field:account.journal,warning_msgs:0
@@ -138,6 +146,11 @@ msgid "Journal"
 msgstr "Diario"
 
 #. module: ecua_payment
+#: field:account.journal,replenishment:0
+msgid "Replenishment"
+msgstr "Reposición"
+
+#. module: ecua_payment
 #: model:ir.actions.act_window,name:ecua_payment.action_replenishment_controlled
 #: model:ir.ui.menu,name:ecua_payment.menu_action_vendor_payment
 msgid "Replenishment controlled"
@@ -149,9 +162,9 @@ msgid "Default Open Balance Reconcile Account"
 msgstr "Saldo de la cuenta abierta a reconciliar por defecto"
 
 #. module: ecua_payment
-#: help:replenishment.controlled,message_ids:0
-msgid "Messages and communication history"
-msgstr "Los mensajes y el historial de comunicaciones"
+#: help:replenishment.controlled,amount_paid:0
+msgid "Indicates the value of the replenishment."
+msgstr "Indica el valor de la reposición."
 
 #. module: ecua_payment
 #: view:account.voucher:0
@@ -191,7 +204,7 @@ msgstr "{'invisible':[('payment_option','!=','with_writeoff')],'required':[('pay
 #. module: ecua_payment
 #: view:account.voucher:0
 msgid "Razon pago"
-msgstr "Razón pago"
+msgstr "Razón del pago"
 
 #. module: ecua_payment
 #: view:replenishment.controlled:0
@@ -205,14 +218,24 @@ msgid "Processed"
 msgstr "Tramitado"
 
 #. module: ecua_payment
-#: view:replenishment.controlled:0
-msgid "Replenishment Controlled"
-msgstr "Reposición de fondos controlados"
+#: help:account.journal,minimun:0
+msgid "Minimun journal money to be controlled."
+msgstr "Valor mínimo de dinero del diario a ser controlado."
 
 #. module: ecua_payment
 #: field:replenishment.controlled,message_ids:0
 msgid "Messages"
 msgstr "Mensajes"
+
+#. module: ecua_payment
+#: help:replenishment.controlled,message_ids:0
+msgid "Messages and communication history"
+msgstr "Los mensajes y el historial de comunicaciones"
+
+#. module: ecua_payment
+#: sql_constraint:replenishment.controlled:0
+msgid "El código de la Reposición debe ser único.!"
+msgstr "El código de la Reposición debe ser único.!"
 
 #. module: ecua_payment
 #: field:account.journal,maximun:0
@@ -225,9 +248,19 @@ msgid "Summary"
 msgstr "Resumen"
 
 #. module: ecua_payment
-#: help:account.journal,replacement:0
+#: view:account.journal:0
+msgid "onchange_type(type,controlled_funds)"
+msgstr "onchange_type(type,controlled_funds)"
+
+#. module: ecua_payment
+#: help:account.journal,replenishment:0
 msgid "Indicates that the journal should have replenishment"
-msgstr "Indica que el diario debe tener reposición de fondos."
+msgstr "Indica que este diario tinne los fondos controlados."
+
+#. module: ecua_payment
+#: help:replenishment.controlled,journal_to_id:0
+msgid "Journal of the replacement destination."
+msgstr "Diario destino de la reposición."
 
 #. module: ecua_payment
 #: help:replenishment.controlled,date:0
@@ -270,14 +303,19 @@ msgid "If checked new messages require your attention."
 msgstr "Se marcan nuevos mensajes que requieren su atención."
 
 #. module: ecua_payment
-#: field:account.journal,replacement:0
-msgid "Replacement"
-msgstr " Reposición"
+#: field:replenishment.controlled,name:0
+msgid "Replenishment fund controlled"
+msgstr "Reposición de fondo controlado"
 
 #. module: ecua_payment
 #: view:replenishment.controlled:0
 msgid "Empresa"
 msgstr "Empresa"
+
+#. module: ecua_payment
+#: help:replenishment.controlled,message_summary:0
+msgid "Holds the Chatter summary (number of messages, ...). This summary is directly in html format in order to be inserted in kanban views."
+msgstr "Mantiene el resumen del Chat ( número de mensajes , ...) . Este resumen está directamente en formato html para ser insertado en vistas kanban ."
 
 #. module: ecua_payment
 #: field:replenishment.controlled,reference:0
@@ -300,6 +338,11 @@ msgid "Accounting Voucher"
 msgstr "Comprobantes contables"
 
 #. module: ecua_payment
+#: view:replenishment.controlled:0
+msgid "Period"
+msgstr "Periodo"
+
+#. module: ecua_payment
 #: field:account.journal,controlled_funds:0
 msgid "Controlled funds"
 msgstr "Fondos Controlados"
@@ -310,14 +353,19 @@ msgid "Unread Messages"
 msgstr "Los mensajes no leídos"
 
 #. module: ecua_payment
-#: help:replenishment.controlled,message_summary:0
-msgid "Holds the Chatter summary (number of messages, ...). This summary is directly in html format in order to be inserted in kanban views."
-msgstr "Mantiene el resumen del Chat ( número de mensajes , ...) . Este resumen está directamente en formato html para ser insertado en vistas kanban ."
+#: view:account.voucher:0
+msgid "Ejemplo: Pago de la factura #43"
+msgstr "Ejemplo: Pago de la factura #43"
 
 #. module: ecua_payment
 #: field:account.journal,minimun:0
 msgid "Minimum"
 msgstr "Mínimo"
+
+#. module: ecua_payment
+#: model:ir.model,name:ecua_payment.model_replenishment_controlled
+msgid "replenishment.controlled"
+msgstr "Reposición de fondos controlados"
 
 #. module: ecua_payment
 #: help:account.journal,warning_msgs:0
@@ -342,5 +390,5 @@ msgstr "Razón para la conciliación"
 #. module: ecua_payment
 #: help:account.journal,default_writeoff_acc_id:0
 msgid "Default account for reconciling the open balance in vouchers, for withhold journals a payable accounts in favor of the partner should be used (ie 2011001 - ANTICIPOS DE CLIENTES)"
-msgstr "Cuenta predeterminada para conciliar el saldo restante en bonos , para retenciones en los diarios de las cuentas que se deben utilizar para pagos en favor del socio(ejm, 2011001 - ANTICIPOS DE CLIENTES)"
+msgstr "Cuenta predeterminada para conciliar el saldo restante en bonos, para retenciones en los diarios de las cuentas que se deben utilizar para pagos en favor del socio(ejm, 2011001 - ANTICIPOS DE CLIENTES)"
 

--- a/ecua_payment/i18n/es.po
+++ b/ecua_payment/i18n/es.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OpenERP Server 7.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-04-18 16:05+0000\n"
-"PO-Revision-Date: 2015-04-18 11:16-0500\n"
+"POT-Creation-Date: 2015-04-20 17:06+0000\n"
+"PO-Revision-Date: 2015-04-20 12:18-0500\n"
 "Last-Translator: Carlos Fernando\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -65,11 +65,6 @@ msgid "Add an internal note..."
 msgstr "Añadir una nota interna..."
 
 #. module: ecua_payment
-#: help:account.journal,maximun:0
-msgid "Maximum journal money to be controlled."
-msgstr "Valor máximo de dinero del diario a ser controlado."
-
-#. module: ecua_payment
 #: field:account.voucher,responsible_id:0
 msgid "Responsible"
 msgstr "Responsable"
@@ -94,6 +89,11 @@ msgstr "Estado"
 #: selection:replenishment.controlled,state:0
 msgid "Draft"
 msgstr "Borrador"
+
+#. module: ecua_payment
+#: help:account.journal,maximun:0
+msgid "Quantity of reference for calculating controlled fund replenishment. It is the maximum value that must be the controlled fund."
+msgstr "Cantidad de referencia para el cálculo de la reposición del fondo controlado. Es el valor máximo que debe tener el fondo controlado."
 
 #. module: ecua_payment
 #: field:replenishment.controlled,narration:0
@@ -129,6 +129,11 @@ msgstr "Referencia a Pago"
 #: view:replenishment.controlled:0
 msgid "Replenishment Controlled"
 msgstr "Reposición de fondos controlados"
+
+#. module: ecua_payment
+#: help:account.journal,minimun:0
+msgid "Quantity of reference for calculating controlled fund replenishment. This field is to calculate the difference between the maximum fund and make replenishing it."
+msgstr "Cantidad de referencia para el cálculo de reposición del fondo controlado. Este campo sirve para calcular la diferencia con el máximo del fondo y hacer la reposición del mismo."
 
 #. module: ecua_payment
 #: field:account.journal,warning_msgs:0
@@ -204,7 +209,7 @@ msgstr "{'invisible':[('payment_option','!=','with_writeoff')],'required':[('pay
 #. module: ecua_payment
 #: view:account.voucher:0
 msgid "Razon pago"
-msgstr "Razón del pago"
+msgstr "Razon pago"
 
 #. module: ecua_payment
 #: view:replenishment.controlled:0
@@ -216,11 +221,6 @@ msgstr "Buscar Reposición de fondos controlados"
 #: selection:replenishment.controlled,state:0
 msgid "Processed"
 msgstr "Tramitado"
-
-#. module: ecua_payment
-#: help:account.journal,minimun:0
-msgid "Minimun journal money to be controlled."
-msgstr "Valor mínimo de dinero del diario a ser controlado."
 
 #. module: ecua_payment
 #: field:replenishment.controlled,message_ids:0

--- a/ecua_payment/objects/account_journal.py
+++ b/ecua_payment/objects/account_journal.py
@@ -82,8 +82,8 @@ class account_journal(osv.osv):
                                                            help="Default account for reconciling the open balance in vouchers, for withhold journals a payable accounts in favor of the partner should be used (ie 2011001 - ANTICIPOS DE CLIENTES)"
                                                            ),
                 'controlled_funds': fields.boolean('Controlled funds', help='Indicates that this journal will be of controlled fund.'),
-                'maximun': fields.float('Maximum', help="Maximum journal money to be controlled."),
-                'minimun': fields.float('Minimum', help="Minimun journal money to be controlled."),
+                'maximun': fields.float('Maximum', help="Quantity of reference for calculating controlled fund replenishment. It is the maximum value that must be the controlled fund."),
+                'minimun': fields.float('Minimum', help="Quantity of reference for calculating controlled fund replenishment. This field is to calculate the difference between the maximum fund and make replenishing it."),
                 'replenishment': fields.function(_validate_replenishment, string="Replenishment", type='boolean', method=True,
                                                              help="Indicates that the journal should have replenishment"),
                 'warning_msgs': fields.function(_get_warning_msgs, string='Warnings',store=False, type='char',method=True, 

--- a/ecua_payment/objects/account_journal.py
+++ b/ecua_payment/objects/account_journal.py
@@ -42,22 +42,23 @@ class account_journal(osv.osv):
         warning_msgs = ''
         journal_info = self.browse(cr, uid, ids, context)
         
-        if journal_info.replacement==True:
+        if journal_info.replenishment==True:
             warning_msgs += 'Se debe realizar reposición de fondos en el diario seleccionado.'
         
         return warning_msgs
     
-    def _validate_replacement(self, cr, uid, ids, field_name, arg, context=None):
+    def _validate_replenishment(self, cr, uid, ids, field_name, arg, context=None):
         """
         Verifica si un diario necesita reposición de fondos.
         Retorna True or False
         """
         res = {}
         
-        journal_data = self.read(cr, uid, ids, ['type','maximun','minimun','default_credit_account_id'])
+        journal_data = self.read(cr, uid, ids, ['type','maximun','minimun','default_credit_account_id','controlled_funds'])
         type = journal_data[0]['type']
+        controlled_funds = journal_data[0]['controlled_funds']
         
-        if type=='bank':
+        if type in ('cash','bank') and controlled_funds==True:
             maximun = journal_data[0]['maximun']
             minimun = journal_data[0]['minimun']
             
@@ -81,31 +82,32 @@ class account_journal(osv.osv):
                                                            help="Default account for reconciling the open balance in vouchers, for withhold journals a payable accounts in favor of the partner should be used (ie 2011001 - ANTICIPOS DE CLIENTES)"
                                                            ),
                 'controlled_funds': fields.boolean('Controlled funds', help='Indicates that this journal will be of controlled fund.'),
-                'maximun': fields.float('Maximum'),
-                'minimun': fields.float('Minimum'),
-                'replacement': fields.function(_validate_replacement, string="Replacement", type='boolean', method=True,
+                'maximun': fields.float('Maximum', help="Maximum journal money to be controlled."),
+                'minimun': fields.float('Minimum', help="Minimun journal money to be controlled."),
+                'replenishment': fields.function(_validate_replenishment, string="Replenishment", type='boolean', method=True,
                                                              help="Indicates that the journal should have replenishment"),
                 'warning_msgs': fields.function(_get_warning_msgs, string='Warnings',store=False, type='char',method=True, 
                                                                    help='There are pending action in this transaction.'),
                 }
     
-    def onchange_valida_maximo(self, cr, uid, ids, field_max, field_min, type):
+    _defaults = {
+                'controlled_funds': False, 
+                }
+    
+    def onchange_validate_maximun(self, cr, uid, ids, field_max, field_min, type):
         """ 
         Valida que los campos field_max y field_max sean mayor a cero y que el 
         campo field_max sea siempre mayor al campo field_min.
-        Se ejecuta siempre que se escoja el diario 'banco y cheques'.
+        Se ejecuta siempre que se escoja los diarios efectivo o 'banco y cheques'.
         """
         res = {'warning':{}}
         
-        if field_max!=0 and field_max!=0 and type=='bank':
+        if field_max!=0 and field_max!=0 and type in ('cash','bank'):
         
             if field_max<=0:
                 raise osv.except_osv(_('Error!'), _('El campo máximo debe ser mayor a cero.'))
             
-            if field_min<=0:
-                raise osv.except_osv(_('Error!'), _('El campo mínimo debe ser mayor a cero.'))
-            
-            if type=='bank' and field_min >= field_max:
+            if type in ('cash','bank') and field_min >= field_max:
                 res = {'warning': {'title': _('Warning!'),
                                    'message': _('El campo Máximo debe ser mayor al campo Mínimo.')}                   
                       }
@@ -118,15 +120,15 @@ class account_journal(osv.osv):
         """        
         res = {'value':{}}
         
-        if type!='bank':
+        if type not in ('cash','bank'):
             controlled_funds=False
         else:
             controlled_funds=True
         
         if controlled_funds==True:
-            res = {'value':{'maximun':False, 'minimun':False, 'replacement':False}}
+            res = {'value':{'maximun':False, 'minimun':False, 'replenishment':False}}
         else:
-            res = {'value':{'controlled_funds':False, 'maximun':False, 'minimun':False, 'replacement':False}}          
+            res = {'value':{'controlled_funds':False, 'maximun':False, 'minimun':False, 'replenishment':False}}          
 
         return res
     
@@ -137,16 +139,14 @@ class account_journal(osv.osv):
         minimun = 0
         
         if values.get('controlled_funds')==True:
-            if values.get('type')=='bank' and (values.has_key('maximun') or values.has_key('minimun')):
+            if values.get('type') in ('cash','bank') and (values.has_key('maximun') or values.has_key('minimun')):
                 if 'maximun' in values:
                     maximun = values.get('maximun')
                     if maximun<=0:
                         raise osv.except_osv(_('Error!'), _('El campo máximo debe ser mayor a cero.'))
                 if 'minimun' in values:
                     minimun = values.get('minimun')
-                    if minimun<=0:
-                        raise osv.except_osv(_('Error!'), _('El campo mínimo debe ser mayor a cero.'))
-        
+                            
                 if minimun >= maximun:
                     raise osv.except_osv(_('Error!'), _('El campo Máximo debe ser mayor al campo Mínimo.'))
             
@@ -162,27 +162,22 @@ class account_journal(osv.osv):
             controlled_funds = self.read(cr, uid, ids, ['controlled_funds'])[0]['controlled_funds']
            
         if controlled_funds==True:
-            if not vals.has_key('maximun') and not vals.has_key('minimun'):
-                raise osv.except_osv(_('Error!'), _('Los valores de máximo y mínimo deben ser mayores a cero.'))
+            if 'maximun' in vals:
+                maximun = vals.get('maximun')
+                if maximun<=0:
+                    raise osv.except_osv(_('Error!'), _('El campo máximo debe ser mayor a cero.'))
             else:
-                if 'maximun' in vals:
-                    maximun = vals.get('maximun')
-                    if maximun<=0:
-                        raise osv.except_osv(_('Error!'), _('El campo máximo debe ser mayor a cero.'))
-                else:
-                    journal_data = self.read(cr, uid, ids, ['maximun']) 
-                    maximun = journal_data[0]['maximun']
-                  
-                if 'minimun' in vals:
-                    minimun = vals.get('minimun')
-                    if minimun<=0:
-                        raise osv.except_osv(_('Error!'), _('El campo mínimo debe ser mayor a cero.'))
-                else:
-                    journal_data = self.read(cr, uid, ids, ['minimun'])
-                    minimun = journal_data[0]['minimun']
-                
-                if minimun >= maximun:
-                    raise osv.except_osv(_('Error!'), _('El campo Máximo debe ser mayor al campo Mínimo.'))
+                journal_data = self.read(cr, uid, ids, ['maximun']) 
+                maximun = journal_data[0]['maximun']
+              
+            if 'minimun' in vals:
+                minimun = vals.get('minimun')
+            else:
+                journal_data = self.read(cr, uid, ids, ['minimun'])
+                minimun = journal_data[0]['minimun']
+            
+            if minimun >= maximun:
+                raise osv.except_osv(_('Error!'), _('El campo Máximo debe ser mayor al campo Mínimo.'))
 
         journal_id = super(account_journal,self).write(cr, uid, ids, vals, context)
         

--- a/ecua_payment/objects/replenishment_controlled.py
+++ b/ecua_payment/objects/replenishment_controlled.py
@@ -51,7 +51,7 @@ class replenishment_controlled(osv.osv):
             state = replenishment['state']
             journal_id = replenishment['journal_to_id']
                         
-            if state != 'processed':                
+            if state != 'processed':
                 journal_data = journal_obj.read(cr, uid, journal_id[0], ['type','maximun','minimun','default_credit_account_id'])
                 type = journal_data['type']
                 
@@ -67,7 +67,7 @@ class replenishment_controlled(osv.osv):
             else:
                 replenishment_data = self.read(cr, uid, id, ['amount_paid_usr'])
                 # Muestra el último valor almacenado mas no lo vuelve a calcular ya que la reposición
-                # ya se encuentra en estado tramitado..
+                # ya se encuentra en estado tramitado. El campo amount_paid_usr es utilizado al momento de crear el pago.
                 res[id] = replenishment_data['amount_paid_usr']
 
         return res
@@ -111,7 +111,7 @@ class replenishment_controlled(osv.osv):
                 
         sequence_obj = self.pool.get('ir.sequence')
         seq_replenishmnet_id = sequence_obj.search(cr, uid,[('name','=','Replenishment-Controlled')])
-        vals['name'] = sequence_obj.next_by_id(cr, uid, seq_replenishmnet_id)        
+        vals['name'] = sequence_obj.next_by_id(cr, uid, seq_replenishmnet_id)
 
         return super(replenishment_controlled, self).create(cr, uid, vals, context)
     

--- a/ecua_payment/views/account_journal_view.xml
+++ b/ecua_payment/views/account_journal_view.xml
@@ -13,7 +13,7 @@
 				</field>
 				
 				<field name="group_invoice_lines" position="after">
-                	<field name="controlled_funds" attrs="{'invisible':[('type','not in',('bank',))]}"
+                	<field name="controlled_funds" attrs="{'invisible':[('type','not in',('cash','bank',))]}"
                 	       on_change="onchange_type(type,controlled_funds)"/>
 				</field>
 				
@@ -22,11 +22,11 @@
                 </field>
 				
 				<field name="sequence_id" position="after">
-                	<field name="maximun" on_change="onchange_valida_maximo(maximun,minimun,type)"
+                	<field name="maximun" on_change="onchange_validate_maximun(maximun,minimun,type)"
                 	       attrs="{'invisible':[('controlled_funds','=',False)],'required':[('controlled_funds','=',True)]}"/>
-                	<field name="minimun" on_change="onchange_valida_maximo(maximun,minimun,type)" 
+                	<field name="minimun" on_change="onchange_validate_maximun(maximun,minimun,type)" 
                 	       attrs="{'invisible':[('controlled_funds','=',False)],'required':[('controlled_funds','=',True)]}"/>
-                	<field name="replacement" invisible="1"/> 
+                	<field name="replenishment" invisible="1"/> 
 				</field>
 				
 				<xpath expr="//div[@class='oe_title']" position="after">

--- a/ecua_payment/views/replenishment_controlled_view.xml
+++ b/ecua_payment/views/replenishment_controlled_view.xml
@@ -24,9 +24,9 @@
 								<field name="partner_id" string="Empresa" widget="selection" readonly="1"/>
 		                       	<field name="amount_paid" readonly="1"/>
 		                       	<field name="amount_paid_usr" invisible="1"/>
-		                        <field name="journal_from_id" domain="[('type','in',('cash','bank'))]"
+		                        <field name="journal_from_id"
 		                               widget="selection" attrs="{'readonly':[('state','!=','draft')]}"/>
-		                        <field name="journal_to_id" domain="[('type','=','bank')]"
+		                        <field name="journal_to_id" domain="[('type','in',('cash','bank')),('controlled_funds','=',True),]"
 		                               widget="selection" on_change="onchange_journal_to_id(journal_to_id)"
 		                               attrs="{'readonly':[('state','!=','draft')]}"/>
 		                    </group> 
@@ -36,6 +36,8 @@
 		                        <field name="account_voucher_id" attrs="{'invisible':[('state','!=','processed')]}" readonly="1"
 		                               context="{'form_view_ref':'account_voucher.view_vendor_payment_form'}"/>
 		                    </group>
+ 		                    <field name="narration" colspan="4" nolabel="1" placeholder="Add an internal note..."
+ 		                           attrs="{'readonly':[('state','!=','draft')]}"/>
 		                </group>                 
                     </sheet>
                     <div class="oe_chatter">
@@ -71,8 +73,9 @@
                     <filter icon="terp-camera_test" string="Confirmed" domain="[('state','=','confirmed')]" help="Confirmed Replenishment Controlled"/>
                     <filter icon="terp-camera_test" string="Processed" domain="[('state','=','processed')]" help="Processed Replenishment Controlled"/>
                     <group expand="0" string="Group By...">
-                        <filter string="Supplier" icon="terp-personal" domain="[]" context="{'group_by':'partner_id'}"/>
                         <filter string="Status" icon="terp-stock_effects-object-colorize" domain="[]" context="{'group_by':'state'}"/>
+                        <filter string="Period" icon="terp-go-month" domain="[]" context="{'group_by':'date'}"/>
+                        <filter string="Journal Destination" icon="terp-stock_effects-object-colorize" domain="[]" context="{'group_by':'journal_to_id'}"/>
                     </group>
                 </search>
             </field>


### PR DESCRIPTION
En el objeto account.journal:
1. Se cambia el nombre del campo replacement a replenishment así como
también sus correspondientes derivados.
2. Se corrige para que el tree pinte solo los diarios que tienen marcado
el check fondos controlados y que necesitan reposición.
3. Se modifica el check fondos controlados para que aparezca cuando el
campo tipo sea "Efectivo" y "Banco y Cheques".
4. Se agrega helper a los campos faltantes.
En el objeto replenishment.controlled:
5. Implementación en Campo A para que filtre solo los diarios que tienes
activo el check fondos controlados.
6. Se agrega el campo Notas internas:
7. Se cambia la secuencia del campo name a Reposicion de Fondo/RFC .....
8. En la vista se agrega el Agrupar por: Periodo y Diario destino.
9. Se implementa auditoría para todos los campos.
10. Se cambia validación del campo minimun para que acepte números
negativos.
11. Se implemmenta validación para que el diario origen y destino no
sean los mismos.