### PR TITLE
CLIENTES-100 algunos valores predeterminados estaban como None. Le pu…

### DIFF
--- a/ecua_tax_withhold/objects/withhold.py
+++ b/ecua_tax_withhold/objects/withhold.py
@@ -300,8 +300,8 @@ class account_withhold(osv.osv):
                             vals_ret_line = {
                                              'fiscalyear_id':fiscalyear_id,  
                                              'description': tax_line['type_ec'],
-                                             'tax_id': tax_id,
-                                             'tax_ac_id': tax_ac_id,
+                                             'tax_id': tax_id or False,
+                                             'tax_ac_id': tax_ac_id or False,
                                              'tax_base': tax_line['base'],
                                              'tax_amount': abs(tax_line['amount']),
                                              'withhold_percentage':0,


### PR DESCRIPTION
…se "or False" para esos casos ya que None no es un valor reconocido por OpenERP. OpenERP espera siempre falsos para los valores que no estan presentes, por lo que pasar un None es una condicion no esperada y hara que OpenERP reviente sin control en esos puntos.