### PR TITLE
FDU-953 Quitamos esta invocación de SQL en el __init__ para que pueda…

### DIFF
--- a/ecua_partner/objects/res_partner.py
+++ b/ecua_partner/objects/res_partner.py
@@ -638,15 +638,15 @@ class res_partner(osv.osv):
             return res2
         return res
 
-    def __init__(self, pool, cr):
-        """
-        TODO eliminar este script luego de una vez de uso!!
-        :param pool:
-        :param cr:
-        :return:
-        """
-        super(res_partner, self).__init__(pool, cr)
-        cr.execute('update res_partner set vat=upper(vat)')
+    #def __init__(self, pool, cr):
+    #    """
+    #    TODO eliminar este script luego de una vez de uso!!
+    #    :param pool:
+    #    :param cr:
+    #    :return:
+    #    """
+    #    super(res_partner, self).__init__(pool, cr)
+    #    cr.execute('update res_partner set vat=upper(vat)')
     
     def name_search(self, cr, user, name='', args=None, operator='ilike', context=None, limit=100):
         '''


### PR DESCRIPTION
… arrancar bien el multicore sin morirse por transacciones concurrentes. Ademas, este SQL ya no es necesario que se ejecute.
